### PR TITLE
Return version of current raspi board.

### DIFF
--- a/mmio.c
+++ b/mmio.c
@@ -5,7 +5,34 @@ uint64_t mmio_base;
 
 inline void get_rpi_version(void)
 {
-	rpi_version = 3;
+	unsigned int reg;
+
+	/* read the system register */
+#if __aarch64__
+	asm volatile ("mrs %x0, midr_el1" : "=r" (reg));
+#else
+	asm volatile ("mrc p15,0,%0,c0,c0,0" : "=r" (reg));
+#endif
+
+	switch ((reg >> 4) & 0xFFF) {
+		case 0xB76: 
+			rpi_version=1;
+			break;
+		case 0xC07: 
+			rpi_version=2;
+			break;
+		case 0xD03: 
+			rpi_version=3; 
+			break;
+		case 0xD08: 
+			rpi_version=4; 
+			break;
+		case 0xD0B:
+			rpi_version=5;
+		default: 
+			rpi_version=0;
+			break;
+	}
 }
 
 inline void mmio_write(uint32_t offset, uint32_t val)


### PR DESCRIPTION
Add function that detect current SoC ID, will help to identify board 
Tested on raspi5, compiled with HobOS didn't tested with HobOS.