### PR TITLE
EL: Adding support for switching to EL1

### DIFF
--- a/boot.S
+++ b/boot.S
@@ -38,6 +38,79 @@ _start:
     add x2, x3, x0
     str x0, [x1]
 
+    bl	curr_core_el
+    cmp	x0, #1
+    beq	1f
+3:
+    cmp	x0, #3
+    bne	2f
+
+    //config SCR_EL3
+    mov x1, #0x1	//EL0/1 are non-secure
+    orr x1, x1, #0x80	//Disable secure monitor
+    orr x1, x1, #0x100	//Enable Hypervisor instructions
+    orr x1, x1, #0x400	//Enable AArch64 for lower exception levels
+    msr	scr_el3, x1
+
+    //config SPSR_EL3
+    mov x1, #0x9	//Drop to EL2 with SP_EL2
+    orr x1, x1, #0xC0	//Mask FIQ, IRQ
+    orr x1, x1, #0x300	//Mask Debug, SError Exceptions
+    msr spsr_el3, x1
+
+    //set return address after returning
+    adr x1, 2f
+    msr elr_el3, x1
+
+    //move to el2
+    eret
+
+2:
+    //cmp	x0, #2
+    //bne 1f
+   
+    //config CNTHCTL_EL2
+    mrs x0, cnthctl_el2
+    orr x0, x0, #0x1		//allow access to counter registers
+    orr x0, x0, #0x2		//allow access to physical timer
+    msr cnthctl_el2, x0
+    msr cntvoff_el2, xzr	//zero counter offset
+
+    //config HCR_EL2
+    mrs x0, hcr_el2
+    orr x0, x0, #0x2		//enable SWIO, hardwired for RPI3
+    orr x0, x0, #(1<<31) 	//enable AArch64 for lower exception levels
+    msr hcr_el2, x0
+
+    //config SCTLR_EL1
+    mov	x0, #0x800		//enable instruction cache
+    //movk x0, #0x30d0, lsl #16
+    mov x0, #(1<<16)		//execute WFI as normal
+    orr x0, x0, #(1<<18)	//execute WFE as normal
+    orr x0, x0, #(1<<19)	//write sections of memory are not executable
+    msr sctlr_el1, x0
+
+    //config SPSR_EL2
+    mov x0, #0x4
+    orr x0, x0, #0xc0
+    orr x0, x0, #0x300
+    msr spsr_el2, x0
+    
+
+    //set EL1 stack pointer
+    adr x1, 1f
+    msr elr_el2, x1
+
+    bl curr_core_id
+    bl core_stack_base
+    msr sp_el1, x0
+
+    //move to EL1
+    eret
+
+1:
+    mov sp, x0
+
     // jump to C code, should not return
 5:  bl      main
     // for failsafe, halt this core too

--- a/kernel.c
+++ b/kernel.c
@@ -7,13 +7,15 @@
 #include "hobos/gpio.h"
 
 extern int setup_stack(void);
+extern uint8_t curr_core_el(void);
+extern void switch_el(void);
 
 /* I'm alive */
 void heartbeat(void)
 {
-	run_process((uint64_t) setup_stack, 1);
-	run_process((uint64_t) setup_stack, 2);
-	run_process((uint64_t) setup_stack, 3);
+	//run_process((uint64_t) setup_stack, 1);
+	//run_process((uint64_t) setup_stack, 2);
+	//run_process((uint64_t) setup_stack, 3);
 }
 
 void main()
@@ -23,16 +25,26 @@ void main()
 	
 	struct gpio_controller ctrl;
 	init_gpio(&ctrl);
-	
 	init_console(&ctrl);
 
-	struct timer t;
-	init_timer(&t);
-	kprintf("timer: %d\n", read_timer(1, &t));
-	kprintf("timer: %d\n", read_timer(1, &t));
+	//kprintf("EL: %d\n", curr_core_el());
+//	kprintf("EL: %d\n", curr_core_el());
+//
 
-	heartbeat();
+	uint8_t x; 
 
+	x = 0xdeadbeef;
+	x = curr_core_el();
+	//kprintf("Hello\n");
+
+//	struct timer t;
+//	init_timer(&t);
+//	kprintf("timer: %d\n", read_timer(1, &t));
+//	kprintf("timer: %d\n", read_timer(1, &t));
+//
+//	heartbeat();
+
+	
 	while (1) {
 		//start shell here
 	}

--- a/proc.S
+++ b/proc.S
@@ -2,6 +2,9 @@
 
 .global setup_stack
 .global curr_core_id
+.global curr_core_el
+.global core_stack_base
+.global switch_el
 
 #define CORE_STACK_BASE	0x86000
 #define CORE_STACK_SIZE	0x1000
@@ -26,6 +29,7 @@ setup_stack:
 1:
     //get stack associated to core id
     ldr x1, =CORE_STACK_BASE
+    //stack grows from high to low
     sub x1, x1, x0
     mov sp, x1
 
@@ -37,8 +41,31 @@ setup_stack:
 exec:
     b park_and_wait
 
+//x0 = core number
+//returns x0 = stack base
+core_stack_base:
+    //get offset from base
+    ldr x2, =CORE_STACK_SIZE
+    mul x0, x0, x2
+
+1:
+    //get stack associated to core id
+    ldr x1, =CORE_STACK_BASE
+    //stack grows from high to low
+    ldr x1, =CORE_STACK_BASE
+    sub x0, x1, x0
+    ret
+
 
 curr_core_id:
     mrs x0, mpidr_el1
     and x0, x0, #0x3
     ret
+
+curr_core_el:
+    mrs x0, CurrentEL
+    and x0, x0, #12
+    lsr x0, x0, #2
+    and x0, x0, #0x0F
+    ret
+


### PR DESCRIPTION
This allows the board to shift from EL2/3 to EL1. This is necessary when working/configuring page tables for EL1/0.

